### PR TITLE
Add missing claims to credential data

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -2237,9 +2237,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "log-symbols": {
       "version": "3.0.0",

--- a/docker/issuer-web/config/web/claim-config.json
+++ b/docker/issuer-web/config/web/claim-config.json
@@ -65,6 +65,27 @@
       "defaultValue": "Canada",
       "isRequired": true,
       "requiredErrorText": "Required Field"
+    },
+    {
+      "type": "text",
+      "name": "issued",
+      "title": "Issued:",
+      "readOnly": true,
+      "isRequired": true
+    },
+    {
+      "type": "text",
+      "name": "placeholder",
+      "defaultValue": "placeholder",
+      "readOnly": true,
+      "visibleIf": "{issued} empty"
+    }
+  ],
+  "triggers": [
+    {
+      "type": "runexpression",
+      "expression": "{placeholder} notempty",
+      "runExpression": "setCurrentISODate('issued')"
     }
   ]
 }

--- a/docker/issuer-web/config/web/config.json
+++ b/docker/issuer-web/config/web/config.json
@@ -3,7 +3,7 @@
   "issuer": {
     "name": "Test Issuer"
   },
-  "inviteRequired": false,
+  "inviteRequired": true,
   "authentication": {
     "enabled": true,
     "oidcSettings": {

--- a/docker/issuer-web/config/web/config.json
+++ b/docker/issuer-web/config/web/config.json
@@ -3,7 +3,7 @@
   "issuer": {
     "name": "Test Issuer"
   },
-  "inviteRequired": true,
+  "inviteRequired": false,
   "authentication": {
     "enabled": true,
     "oidcSettings": {

--- a/docker/issuer-web/config/web/custom-scripts.js
+++ b/docker/issuer-web/config/web/custom-scripts.js
@@ -1,7 +1,19 @@
 /* Include all your custom JS code in here, it will be available to the app instance */
 
+function setCurrentISODate(params) {
+    if (params.length < 1) {
+      throw new Error(
+        "setCurrentISODate is missing one or more required parameters"
+      );
+    }
+    var dateField = params[0];
+    var survey = this.survey;
+  
+    var date = new Date();
+    survey.setValue(dateField, date.toISOString());
+  }
 
 /* An array containing custom functions that will be automatically registered with
  * SurveyJS so that they can be used in triggers.
  */
-surveyFunctions = [];
+surveyFunctions = [setCurrentISODate];

--- a/issuer-admin/package-lock.json
+++ b/issuer-admin/package-lock.json
@@ -4992,6 +4992,12 @@
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
         },
+        "lodash": {
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+          "dev": true
+        },
         "mimic-fn": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -7273,9 +7279,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "lodash.defaultsdeep": {

--- a/issuer-web/package-lock.json
+++ b/issuer-web/package-lock.json
@@ -4992,6 +4992,12 @@
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
         },
+        "lodash": {
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+          "dev": true
+        },
         "mimic-fn": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -7273,9 +7279,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "lodash.defaultsdeep": {

--- a/issuer-web/public/config/claim-config.json
+++ b/issuer-web/public/config/claim-config.json
@@ -65,6 +65,27 @@
       "defaultValue": "Canada",
       "isRequired": true,
       "requiredErrorText": "Required Field"
+    },
+    {
+      "type": "text",
+      "name": "issued",
+      "title": "Issued:",
+      "readOnly": true,
+      "isRequired": true
+    },
+    {
+      "type": "text",
+      "name": "placeholder",
+      "defaultValue": "placeholder",
+      "readOnly": true,
+      "visibleIf": "{issued} empty"
+    }
+  ],
+  "triggers": [
+    {
+      "type": "runexpression",
+      "expression": "{placeholder} notempty",
+      "runExpression": "setCurrentISODate('issued')"
     }
   ]
 }

--- a/issuer-web/public/config/custom-scripts.js
+++ b/issuer-web/public/config/custom-scripts.js
@@ -1,10 +1,19 @@
-/* Include all your custom JS code in here, it will be available to the app instance on the window object */
+/* Include all your custom JS code in here, it will be available to the app instance */
 
-function myCoolFunction() {
-  console.log("Do something great here.");
+function setCurrentISODate(params) {
+  if (params.length < 1) {
+    throw new Error(
+      "setCurrentISODate is missing one or more required parameters"
+    );
+  }
+  var dateField = params[0];
+  var survey = this.survey;
+
+  var date = new Date();
+  survey.setValue(dateField, date.toISOString());
 }
 
-/* All custom functions that will be used in SurveyJS triggers
- * must be listed in this array, so that they will be automatically registered.
- */
-surveyFunctions = [myCoolFunction];
+/* An array containing custom functions that will be automatically registered with
+* SurveyJS so that they can be used in triggers.
+*/
+surveyFunctions = [setCurrentISODate];

--- a/openshift/templates/issuer-web/config/bc/claim-config.json
+++ b/openshift/templates/issuer-web/config/bc/claim-config.json
@@ -65,6 +65,27 @@
       "defaultValue": "Canada",
       "isRequired": true,
       "requiredErrorText": "Required Field"
+    },
+    {
+      "type": "text",
+      "name": "issued",
+      "title": "Issued:",
+      "readOnly": true,
+      "isRequired": true
+    },
+    {
+      "type": "text",
+      "name": "placeholder",
+      "defaultValue": "placeholder",
+      "readOnly": true,
+      "visibleIf": "{issued} empty"
+    }
+  ],
+  "triggers": [
+    {
+      "type": "runexpression",
+      "expression": "{placeholder} notempty",
+      "runExpression": "setCurrentISODate('issued')"
     }
   ]
 }

--- a/openshift/templates/issuer-web/config/bc/custom-scripts.js
+++ b/openshift/templates/issuer-web/config/bc/custom-scripts.js
@@ -1,7 +1,19 @@
 /* Include all your custom JS code in here, it will be available to the app instance */
 
+function setCurrentISODate(params) {
+    if (params.length < 1) {
+      throw new Error(
+        "setCurrentISODate is missing one or more required parameters"
+      );
+    }
+    var dateField = params[0];
+    var survey = this.survey;
+  
+    var date = new Date();
+    survey.setValue(dateField, date.toISOString());
+  }
 
 /* An array containing custom functions that will be automatically registered with
  * SurveyJS so that they can be used in triggers.
  */
-surveyFunctions = [];
+surveyFunctions = [setCurrentISODate];


### PR DESCRIPTION
Added missing `issued` field to credential data - starting with aca-py 0.5.2 a validation error was being thrown.