### PR TITLE
Update readiness and liveness probes

### DIFF
--- a/openshift/templates/agent/agent-deploy.yaml
+++ b/openshift/templates/agent/agent-deploy.yaml
@@ -261,15 +261,20 @@ objects:
               readinessProbe:
                 timeoutSeconds: 30
                 initialDelaySeconds: 3
-                httpGet:
-                  path: /
-                  port: ${{AGENT_HTTP_PORT}}
+                exec:
+                  command:
+                    - bash
+                    - "-c"
+                    - 'curl --fail "http://localhost:${ADMIN_INTERFACE_PORT}/status/ready" -H "X-API-KEY: ${AGENT_ADMIN_API_KEY}"'
               livenessProbe:
                 timeoutSeconds: 30
                 initialDelaySeconds: 300
-                httpGet:
-                  path: /
-                  port: ${{AGENT_HTTP_PORT}}
+                exec:
+                  command:
+                    - bash
+                    - "-c"
+                    - 'curl --fail "http://localhost:${ADMIN_INTERFACE_PORT}/status/live" -H "X-API-KEY: ${AGENT_ADMIN_API_KEY}"'
+
               imagePullPolicy: IfNotPresent
               resources:
                 limits:


### PR DESCRIPTION
- Update to use aries 0.5.3 health check endpoints.

Signed-off-by: Wade Barnes <wade.barnes@shaw.ca>