### PR TITLE
Include Lissi Wallet

### DIFF
--- a/docs/GettingApp.md
+++ b/docs/GettingApp.md
@@ -1,6 +1,6 @@
 # Getting a Mobile Wallet
 
-Use these instructions to get a compatible mobile app on your phone that can receive, hold and prove your verifiable credentials. There are currently two options from [Trinsic](#trinsic-wallet) and [esatus](#esatus-wallet).
+Use these instructions to get a compatible mobile app on your phone that can receive, hold and prove your verifiable credentials. There are currently three options from [Trinsic](#trinsic-wallet), [esatus](#esatus-wallet) and [Lissi] (#Lissi-wallet). 
 
 ## Trinsic Wallet
 
@@ -41,3 +41,21 @@ After installing and opening the mobile wallet, follow the instructions to confi
 - Click the back arrow to return to the settings and again to return to the main app screen.
 
 That's it for the special instructions! Please return to the instructions for application you are using.
+
+## Lissi Wallet
+
+[Lissi](https://lissi.id/) by the [main incubator GmbH](https://main-incubator.com/) ([main incubator - EN](https://main-incubator.com/en/home/)) provides a compatible wallet for both iOS and Android. To use the app you need to install the app from the App- or Playstore. Please follow the setup instructions below for the initial setup:
+
+Links to download the Lissi Wallet:
+
+- [Apple iOS](https://apps.apple.com/de/app/lissi/id1501321092)
+- [Google Android](https://play.google.com/store/apps/details?id=io.lissi.mobile)
+
+After installing and opening the mobile wallet, follow the instructions in the onbaroding screens to configure the wallet with appropriate permissions. After setup, you will be taken to the main app screen. Before continuing with a BC Gov identity service, you must do some additional setup, as followed:
+
+- Go to settings by clicking the cog icon in the top right
+- Click on the "Change Ledger" item and from the subsequent list select one of the following:
+  - If you are using a production service, select "Sovrin MainNet"
+  - If you are using a proof-of-concept service, select "Sovrin StagingNet"
+  - If you are using a proof-of-concept service that instructs you to use the BCovrin test ledger, select "BCGov Test Ledger"
+- Click the back arrow to return to the settings and again to return to the main app screen.


### PR DESCRIPTION
Added Lissi wallet as option for the BC Gov issuer kit. 
Changed two to three options within intro sentence. 
Changed links to website / App- & Playstore accordingly. 
Slightly adjusted description text for the Lissi wallet.

Adrian Doerk - Lissi Team

Signed-off-by: Adrian Doerk <doerkadrian@protonmail.com>