### PR TITLE
Update agent image to 0.5.4-beta2 and add tails server startup parameter

### DIFF
--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -1,3 +1,3 @@
-FROM bcgovimages/aries-cloudagent:py36-1.15-0_0.5.2
+FROM bcgovimages/aries-cloudagent:py36-1.15-0_0.5.4-beta2
 
 RUN echo "Just pulling the image from Docker Hub"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -177,7 +177,7 @@ services:
   # Issuer Kit Agent
   #
   agent:
-    image: bcgovimages/aries-cloudagent:py36-1.15-0_0.5.2
+    image: bcgovimages/aries-cloudagent:py36-1.15-0_0.5.4-beta2
     environment:
       - LEDGER_URL=${LEDGER_URL}
       - WALLET_TYPE=${AGENT_STORAGE_WALLET_TYPE}
@@ -193,6 +193,7 @@ services:
       - AGENT_ADMIN_PORT=${AGENT_ADMIN_PORT}
       - AGENT_NAME=${AGENT_NAME}
       - AGENT_ADMIN_API_KEY=${AGENT_ADMIN_API_KEY}
+      - TAILS_SERVER_BASE_URL=${TAILS_SERVER_BASE_URL}
     networks:
       - issuer_kit
     ports:
@@ -226,7 +227,8 @@ services:
         --seed '${AGENT_WALLET_SEED}' \
         --admin '0.0.0.0' ${AGENT_ADMIN_PORT} \
         --${AGENT_ADMIN_MODE} \
-        --label ${AGENT_NAME}",
+        --label ${AGENT_NAME} \
+        --tails-server-base-url ${TAILS_SERVER_BASE_URL}",
       ]
 
   #

--- a/docker/manage
+++ b/docker/manage
@@ -288,6 +288,7 @@ configureEnvironment() {
   if [ ! -z "${AGENT_ADMIN_API_KEY}" ]; then
     AGENT_ADMIN_MODE="admin-api-key ${AGENT_ADMIN_API_KEY}"
   fi
+  export TAILS_SERVER_BASE_URL=${TAILS_SERVER_BASE_URL:-https://tails-server-dev.pathfinder.gov.bc.ca}
 
   # api
   export API_PORT=5000

--- a/openshift/templates/agent/agent-deploy.bc.param
+++ b/openshift/templates/agent/agent-deploy.bc.param
@@ -21,6 +21,7 @@ ADMIN_API_KEY=[a-zA-Z0-9]{16}
 AGENT_HTTP_PORT=8021
 GENESIS_FILE_URL=https://raw.githubusercontent.com/sovrin-foundation/sovrin/stable/sovrin/pool_transactions_sandbox_genesis
 LOG_LEVEL=WARNING
+TAILS_SERVER_BASE_URL=https://tails-server-dev.pathfinder.gov.bc.ca
 WALLET_STORAGE_TYPE=postgres_storage
 WALLET_HOST=identity-kit-wallet
 WALLET_HOST_PORT=5432

--- a/openshift/templates/agent/agent-deploy.bc.prod.param
+++ b/openshift/templates/agent/agent-deploy.bc.prod.param
@@ -21,6 +21,7 @@ AGENT_BASE_URL=https://identity-kit-agent.pathfinder.gov.bc.ca
 # AGENT_HTTP_PORT=8021
 # GENESIS_FILE_URL=https://raw.githubusercontent.com/sovrin-foundation/sovrin/stable/sovrin/pool_transactions_sandbox_genesis
 # LOG_LEVEL=WARNING
+TAILS_SERVER_BASE_URL=https://tails-server-test.pathfinder.gov.bc.ca
 # WALLET_STORAGE_TYPE=postgres_storage
 # WALLET_HOST=identity-kit-wallet
 # WALLET_HOST_PORT=5432

--- a/openshift/templates/agent/agent-deploy.bc.test.param
+++ b/openshift/templates/agent/agent-deploy.bc.test.param
@@ -21,6 +21,7 @@ AGENT_BASE_URL=https://identity-kit-agent-devex-von-test.pathfinder.gov.bc.ca
 # AGENT_HTTP_PORT=8021
 # GENESIS_FILE_URL=https://raw.githubusercontent.com/sovrin-foundation/sovrin/stable/sovrin/pool_transactions_sandbox_genesis
 # LOG_LEVEL=WARNING
+TAILS_SERVER_BASE_URL=https://tails-server-test.pathfinder.gov.bc.ca
 # WALLET_STORAGE_TYPE=postgres_storage
 # WALLET_HOST=identity-kit-wallet
 # WALLET_HOST_PORT=5432

--- a/openshift/templates/agent/agent-deploy.yaml
+++ b/openshift/templates/agent/agent-deploy.yaml
@@ -135,7 +135,8 @@ objects:
                   --admin '0.0.0.0' ${ADMIN_INTERFACE_PORT}
                   $([ ! -z "${AGENT_ADMIN_API_KEY}" ] && echo "--admin-api-key ${AGENT_ADMIN_API_KEY}" || echo "--admin-insecure-mode")
                   --label "${AGENT_NAME}"
-                  --log-level ${AGENT_LOG_LEVEL});
+                  --log-level ${AGENT_LOG_LEVEL})
+                  --tails-server-base-url ${TAILS_SERVER_BASE_URL};
               env:
                 - name: GENESIS_URL
                   value: ${GENESIS_FILE_URL}
@@ -198,6 +199,8 @@ objects:
                   value: ${AGENT_BASE_URL}
                 - name: AGENT_LOG_LEVEL
                   value: ${LOG_LEVEL}
+                - name: TAILS_SERVER_BASE_URL
+                  value: ${TAILS_SERVER_BASE_URL}
               image:
               ports:
                 - containerPort: ${{AGENT_ADMIN_PORT}}
@@ -384,6 +387,11 @@ parameters:
     description: The logging level for the agent.
     required: true
     value: WARNING
+  - name: TAILS_SERVER_BASE_URL
+    displayName: Tails Server Base Url
+    description: The base URL for the Tails Server.
+    required: true
+    value: https://tails-server-dev.pathfinder.gov.bc.ca
   # ===============================================================================
   # Wallet Configuration
   #--------------------------------------------------------------------------------


### PR DESCRIPTION
Changes deployed and tested for Identity Kit. No revocation registry is created - none of our issuers do right now.