### PR TITLE
Update api to use new revocation endpoint in agent. 

### DIFF
--- a/api/src/services/aries-agent/aries-agent.class.ts
+++ b/api/src/services/aries-agent/aries-agent.class.ts
@@ -155,10 +155,14 @@ export class AriesAgent {
     logger.debug(
       `Attempting revocation for id [${revocation_id}] on registry [${revoc_reg_id}]`
     );
-    const url = `${this.acaPyUtils.getAdminUrl()}/issue-credential/revoke?cred_rev_id=${revocation_id}&rev_reg_id=${revoc_reg_id}&publish=true`;
+    const url = `${this.acaPyUtils.getAdminUrl()}/revocation/revoke`;
     const response = await Axios.post(
       url,
-      null,
+      {
+        cred_rev_id: revocation_id,
+        rev_reg_id: revoc_reg_id,
+        publish: true,
+      },
       this.acaPyUtils.getRequestConfig()
     );
     return response.status === 200;

--- a/docker/api/config/schemas.json
+++ b/docker/api/config/schemas.json
@@ -17,7 +17,7 @@
       "given_names"
     ],
     "default": true,
-    "revocable": false,
+    "revocable": true,
     "tag": "issuer-kit-demo",
     "public": false
   }


### PR DESCRIPTION
Update api to use new revocation endpoint in agent. 
Default to revocable credential for demo mode.

Signed-off-by: Emiliano Suñé <emiliano.sune@gmail.com>