### PR TITLE
fix(LE_certificates):

### DIFF
--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -1,0 +1,5 @@
+FROM issuer-kit-api:intermediate
+
+USER root
+
+RUN yum install -y ca-certificates

--- a/docker/manage
+++ b/docker/manage
@@ -159,12 +159,15 @@ DEV_CONTAINERS="api-dev issuer-admin-dev issuer-web-dev"
 build-api() {
   BASE_IMAGE="centos/nodejs-12-centos7"
   echo "Building issuer-kit-api image using $BASE_IMAGE as base..."
-  
+
   ${S2I_EXE} build \
     --copy \
     '../api' \
     $BASE_IMAGE \
-    'issuer-kit-api'
+    'issuer-kit-api:intermediate'
+    docker build \
+      -t 'issuer-kit-api:latest' \
+      -f '../docker/api/Dockerfile' '../'
 }
 
 build-issuer-admin() {


### PR DESCRIPTION
- adding necessary build steps so that api server root certificate are
up to date. Because otherwise, if your other endpoints have a LE
certificate, you will end up with a infinitely loading
issuer-admin web page.