### PR TITLE
Fix for error: jwt malformed {"name":"JsonWebTokenError"}

### DIFF
--- a/api/src/utils/hooks.ts
+++ b/api/src/utils/hooks.ts
@@ -155,5 +155,9 @@ function extractIdToken(authHeader: string | undefined): string | undefined {
   if (!authHeader || authHeader.split(" ").length === 1) {
     return undefined;
   }
-  return authHeader.split(" ")[1];
+  const token = authHeader.split(" ")[1];
+  if (token === 'null' || token === 'undefined') {
+    return undefined;
+  }
+  return token
 }


### PR DESCRIPTION
- This issue occurred when the authorization header contains a null Bearer token; `authorization: Bearer null`
- `extractIdToken` would parse the `null` as a string which would then lead to the error when the string was decoded as a jwt.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>