### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,30 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.217.4/containers/typescript-node/.devcontainer/base.Dockerfile
+
+# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
+ARG VARIANT="16-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node packages
+# RUN su node -c "npm install -g <your-package-list -here>"
+
+# Install s2i
+ARG S2I_VERSION=v1.3.1
+RUN mkdir -p /tmp/s2i && \
+    curl -s https://api.github.com/repos/openshift/source-to-image/releases/tags/${S2I_VERSION}| grep browser_download_url | grep linux-amd64 | cut -d '"' -f 4 | wget -qi - -P /tmp/s2i/ && \
+    tar -xvf /tmp/s2i/source-to-image*.gz -C /tmp/s2i && \
+    mv /tmp/s2i/s2i /usr/local/bin && mv /tmp/s2i/sti /usr/local/bin && \
+    rm -rf /tmp/s2i
+
+# Install ngrok
+RUN curl -s https://ngrok-agent.s3.amazonaws.com/ngrok.asc | tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null && \
+    echo "deb https://ngrok-agent.s3.amazonaws.com buster main" | tee /etc/apt/sources.list.d/ngrok.list && \
+    apt update && \
+    apt install ngrok

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.217.4/containers/typescript-node
+{
+	"name": "Node.js & TypeScript",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick a Node version: 16, 14, 12.
+		// Append -bullseye or -buster to pin to an OS version.
+		// Use -bullseye variants on local on arm64/Apple Silicon.
+		"args": { 
+			"VARIANT": "16"
+		}
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"dbaeumer.vscode-eslint"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "yarn install",
+
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "node",
+	"features": {
+		"docker-from-docker": "latest"
+	}
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,4 @@
 *.conf text eol=lf
 **/s2i/bin/* text eol=lf
 **/root/**/* text eol=lf
+manage text eol=lf

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,7 +21,13 @@ services:
       PUBLIC_SITE_URL: ${PUBLIC_SITE_URL}
       LOG_LEVEL: ${LOG_LEVEL}
     volumes:
-      - ../api:/usr/src/api
+    # ToDo:
+    #   - When running in Docker-from-Docker the mount needs to be the path to the file/folder
+    #     on the host OS.  Which is different than the /workspaces/<project-name>/* path
+    #     that gets resolved from inside the devcontainer.
+    #   - Figure out a way to fix or workaround this.
+    #   - Perhaps some tips here; https://github.com/docker/compose-cli/issues/1795
+      - /c/Users/wade/git-repos/issuer-kit/api:/usr/src/api
     ports:
       - ${API_PORT}:${API_PORT}
     networks:
@@ -50,7 +56,13 @@ services:
       LOG_LEVEL: ${LOG_LEVEL}
       S2I_SCRIPTS_PATH: ${S2I_SCRIPTS_PATH}
     volumes:
-      - ./api/config:/opt/app-root/src/config
+    # ToDo:
+    #   - When running in Docker-from-Docker the mount needs to be the path to the file/folder
+    #     on the host OS.  Which is different than the /workspaces/<project-name>/* path
+    #     that gets resolved from inside the devcontainer.
+    #   - Figure out a way to fix or workaround this.
+    #   - Perhaps some tips here; https://github.com/docker/compose-cli/issues/1795
+      - /c/Users/wade/git-repos/issuer-kit/docker/api/config:/opt/app-root/src/config
     ports:
       - ${API_PORT}:${API_PORT}
     networks:
@@ -69,7 +81,13 @@ services:
   issuer-admin-dev:
     image: node:erbium
     volumes:
-      - ../issuer-admin:/usr/src/issuer-admin
+    # ToDo:
+    #   - When running in Docker-from-Docker the mount needs to be the path to the file/folder
+    #     on the host OS.  Which is different than the /workspaces/<project-name>/* path
+    #     that gets resolved from inside the devcontainer.
+    #   - Figure out a way to fix or workaround this.
+    #   - Perhaps some tips here; https://github.com/docker/compose-cli/issues/1795
+      - /c/Users/wade/git-repos/issuer-kit/issuer-admin:/usr/src/issuer-admin
     working_dir: /usr/src/issuer-admin
     ports:
       - ${ISSUER_ADMIN_PORT}:${ISSUER_ADMIN_PORT}
@@ -86,8 +104,14 @@ services:
       API_HOST: ${ADMIN_API_HOST}
       API_PORT: ${ADMIN_API_PORT}
     volumes:
-      - ./issuer-admin/config/Caddyfile:/etc/caddy/Caddyfile
-      - ./issuer-admin/config/admin:/srv/config
+    # ToDo:
+    #   - When running in Docker-from-Docker the mount needs to be the path to the file/folder
+    #     on the host OS.  Which is different than the /workspaces/<project-name>/* path
+    #     that gets resolved from inside the devcontainer.
+    #   - Figure out a way to fix or workaround this.
+    #   - Perhaps some tips here; https://github.com/docker/compose-cli/issues/1795
+      - /c/Users/wade/git-repos/issuer-kit/docker/issuer-admin/config/Caddyfile:/etc/caddy/Caddyfile
+      - /c/Users/wade/git-repos/issuer-kit/docker/issuer-admin/config/admin:/srv/config
     ports:
       - ${ADMIN_WEB_HOST_PORT}:${ADMIN_WEB_HOST_PORT}
     networks:
@@ -99,7 +123,13 @@ services:
   issuer-web-dev:
     image: node:erbium
     volumes:
-      - ../issuer-web:/usr/src/issuer-web
+    # ToDo:
+    #   - When running in Docker-from-Docker the mount needs to be the path to the file/folder
+    #     on the host OS.  Which is different than the /workspaces/<project-name>/* path
+    #     that gets resolved from inside the devcontainer.
+    #   - Figure out a way to fix or workaround this.
+    #   - Perhaps some tips here; https://github.com/docker/compose-cli/issues/1795
+      - /c/Users/wade/git-repos/issuer-kit/issuer-web:/usr/src/issuer-web
     working_dir: /usr/src/issuer-web
     ports:
       - ${ISSUER_WEB_PORT}:${ISSUER_WEB_PORT}
@@ -116,8 +146,14 @@ services:
       API_HOST: ${PUBLIC_API_HOST}
       API_PORT: ${PUBLIC_API_PORT}
     volumes:
-      - ./issuer-web/config/Caddyfile:/etc/caddy/Caddyfile
-      - ./issuer-web/config/web:/srv/config
+    # ToDo:
+    #   - When running in Docker-from-Docker the mount needs to be the path to the file/folder
+    #     on the host OS.  Which is different than the /workspaces/<project-name>/* path
+    #     that gets resolved from inside the devcontainer.
+    #   - Figure out a way to fix or workaround this.
+    #   - Perhaps some tips here; https://github.com/docker/compose-cli/issues/1795
+      - /c/Users/wade/git-repos/issuer-kit/docker/issuer-web/config/Caddyfile:/etc/caddy/Caddyfile
+      - /c/Users/wade/git-repos/issuer-kit/docker/issuer-web/config/web:/srv/config
     ports:
       - ${PUBLIC_WEB_HOST_PORT}:${PUBLIC_WEB_HOST_PORT}
     networks:
@@ -157,7 +193,13 @@ services:
       ROOT_LOGLEVEL: ${KEYCLOAK_ROOT_LOGLEVEL}
       KEYCLOAK_IMPORT: ${KEYCLOAK_IMPORT}
     volumes:
-      - ../docker/keycloak/config/realm-export-docker.json:/tmp/realm-export-docker.json
+    # ToDo:
+    #   - When running in Docker-from-Docker the mount needs to be the path to the file/folder
+    #     on the host OS.  Which is different than the /workspaces/<project-name>/* path
+    #     that gets resolved from inside the devcontainer.
+    #   - Figure out a way to fix or workaround this.
+    #   - Perhaps some tips here; https://github.com/docker/compose-cli/issues/1795
+      - /c/Users/wade/git-repos/issuer-kit/docker/keycloak/config/realm-export-docker.json:/tmp/realm-export-docker.json
     ports:
       - 8180:8080
     depends_on:

--- a/docker/manage
+++ b/docker/manage
@@ -2,7 +2,11 @@
 export MSYS_NO_PATHCONV=1
 # getDockerHost; for details refer to https://github.com/bcgov/DITP-DevOps/tree/main/code/snippets#getdockerhost
 . /dev/stdin <<<"$(cat <(curl -s --raw https://raw.githubusercontent.com/bcgov/DITP-DevOps/main/code/snippets/getDockerHost))" 
-export DOCKERHOST=$(getDockerHost)
+# export DOCKERHOST=$(getDockerHost)
+
+# ToDo:
+#   - When running in Docker from Docker, properly detect the underlying OS when resolving the DockerHost address.
+export DOCKERHOST=host.docker.internal
 set -e
 
 #


### PR DESCRIPTION
This PR is a WIP.  There are some outstanding items that need to be resolved before the devcontainer would become viable.

TODO:
  - Correctly resolve underlying host OS when running in Docker-from-Docker.
    - Resolve DockerHost based on host OS.
  - Resolve docker and docker-compose file/folder mount paths back to their location on the host, rather than their location on the devcontainer.  See notes in the code regarding the issues here.

Other than the listed issues.  The project appears to run fine using Docker-from-Docker in the devcontainer and is able to connect to external resources such as a local instance of `von-network` started separately on the host.  The advantage of docker-from-docker is you're using the host's docker installation so containers are built and run on the host (through the devcontainer).

When Docker-in-Docker is used for the devcontainer the above items are not an issue since the docker instance is isolated to the devcontainer.  The disadvantage is that the containers are built and run inside the container and can't see (by default) any containers running on the host, such as an instance of `von-network` running on the host.  Therefore `von-network` would have to be run inside the devcontainer.