### PR TITLE
fixed schema parsing when schema_id is provided

### DIFF
--- a/api/src/services/credential-exchange/credential-exchange.class.ts
+++ b/api/src/services/credential-exchange/credential-exchange.class.ts
@@ -65,24 +65,25 @@ export class CredentialExchange implements ServiceSwaggerAddon {
         );
       }
       schema_id = default_schema.schema_id || default_schema.schema.id;
-
-      //allows blank attributes to be supplied in isser-web/admin
-      const schemaChunks = schema_id.split(':');
-      const schemaVersion = schemaChunks[schemaChunks.length - 1];
-      const schemaName = schemaChunks[schemaChunks.length - 2];
-      const schemaAttributes = getSchemaAttrsByID(schemaName, schemaVersion);
-      const requestAttributes = data.claims.map((claim) => claim.name);
-
-      //take the set difference
-      const diff = schemaAttributes.filter(attr => !requestAttributes.includes(attr));
-      const diffAttrs = diff.map((attr) =>
-      ({
-        name: attr,
-        value: "",
-        "mime-type": "text/plain",
-      } as AriesCredentialAttribute));
-      attributes.push(...diffAttrs);
     }
+    
+    //allows blank attributes to be supplied in isser-web/admin
+    const schemaChunks = schema_id.split(':');
+    const schemaVersion = schemaChunks[schemaChunks.length - 1];
+    const schemaName = schemaChunks[schemaChunks.length - 2];
+    const schemaAttributes = getSchemaAttrsByID(schemaName, schemaVersion);
+    const requestAttributes = data.claims.map((claim) => claim.name);
+
+    //take the set difference
+    const diff = schemaAttributes.filter(attr => !requestAttributes.includes(attr));
+    const diffAttrs = diff.map((attr) =>
+    ({
+      name: attr,
+      value: "",
+      "mime-type": "text/plain",
+    } as AriesCredentialAttribute));
+    attributes.push(...diffAttrs);
+
     const cred_def_id = this.app.get("credDefs").get(schema_id) as string;
 
     const credentialOffer = formatCredentialOffer(

--- a/api/src/utils/credential-exchange.ts
+++ b/api/src/utils/credential-exchange.ts
@@ -8,6 +8,8 @@ import {
 import { HookContext } from "@feathersjs/feathers";
 import { ServiceType, ServiceAction } from "../models/enums";
 import { GeneralError } from "@feathersjs/errors";
+import { loadJSON } from "./load-config-file";
+import { SchemaDefinition } from "../models/schema";
 
 export function formatCredentialOffer(
   connection_id: string,
@@ -36,6 +38,16 @@ export function formatCredentialPreview(
       "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/credential-preview",
     attributes: attributes,
   };
+}
+
+export function getSchemaAttrsByID(schema_name: string, schema_version: string): string[] {
+  const schemas = loadJSON("schemas.json") as SchemaDefinition[];
+  const filtered = schemas.filter((s) => s.schema_name === schema_name && s.schema_version === schema_version);
+  let schemaAttributes: string[] = [];
+  if (filtered.length > 0 && filtered[0].attributes) {
+    schemaAttributes = filtered[0].attributes;
+  }
+  return schemaAttributes;
 }
 
 export async function revokeCredential(context: HookContext) {


### PR DESCRIPTION
Fixed blank attribute parsing when schema_id is provided. 
Previously the code for processing blank attributes in a credential request was in the wrong scope so if the schema_id was provided then the code would never be executed.  
Signed-off-by: wadeking98 <wkingnumber2@gmail.com>