### PR TITLE
load credDef ID from config file if it exists

### DIFF
--- a/api/src/models/schema.ts
+++ b/api/src/models/schema.ts
@@ -31,6 +31,7 @@ export interface SchemaDefinition {
   attributes?: string[];
   revocable?: boolean;
   tag?: string;
+  cred_def_id?: string;
   default?: boolean;
   public?: boolean;
 }


### PR DESCRIPTION
With the updated aca-py version, the POST endpoints `/schemas` and `/credential-definitions` now return a 400 error when writing to the ledger if the schema or cred def already exists.

The issue with creating a new schema can be solved by simply adding an `id` field to each member of the schemas.json file.

For the issue with creating a new credential definition, I added code to look for the field `cred_def_id` in each member for the schemas.json file. If `cred_def_id` is found then the api won't try to write a new credential definition to the ledger.

I have deployed this code in the DEV environment and I have confirmed that it works as expected.
Resolves: #381 
Signed-off-by: wadeking98 <wkingnumber2@gmail.com>