### PR TITLE
fix: fixed the deeplink href on issuer-web

### DIFF
--- a/issuer-web/src/views/Connect.vue
+++ b/issuer-web/src/views/Connect.vue
@@ -23,7 +23,7 @@
       <QRCode v-if="qrKey > 0" :value="inviteURL" :width="width" :key="qrKey" />
 
       <v-container>
-        <v-btn color="white" :h="`${deeplinkPrefix}?d_m=${base64Invitation}`">
+        <v-btn color="white" :href="`${deeplinkPrefix}?d_m=${base64Invitation}`">
           <v-icon left light>fas fa-external-link-alt</v-icon>
           Open in a Trusted Digital Wallet
         </v-btn>


### PR DESCRIPTION
Signed-off-by: wadeking98 <wkingnumber2@gmail.com>  

Changed the `h` prop to `href`. There is no `h` prop in the [v-btn api](https://next.vuetifyjs.com/en/api/v-btn/#props-href), I suspect it was a typo.
This change makes the deeplink function as desired.

Resolves: https://github.com/bcgov/bc-wallet-mobile/issues/669